### PR TITLE
Fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/worldcoin/ptau-deserializer
 
-go 1.22
+go 1.22.0
 
 require github.com/consensys/gnark v0.10.0
 


### PR DESCRIPTION
otherwise i get this:
```bash
❯ go build
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```
found solution here: https://github.com/golang/go/issues/65568#issuecomment-1932597413